### PR TITLE
AUT-5242 sample app doesn't display non-JSON resource server response

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Callback endpoint available at: http://localhost:18888/callback
 ```
 make run
 ```
-10. Now, after getting an access token you will have the option to choose 'Fetch Balance' on the access token screen.
+10. Now, after getting an access token you will have the option to choose 'Call Resource Server API' on the access token screen.
 11. Create a sample policy (link below with step by step instructions and screen shots.)
  1. Choose "Policies" on the left menu.
  2. Choose "Create Policy". Choose "API Request" as the Policy type. Give the policy a name and choose "Cloudentity" as the policy language and choose "Create".

--- a/handler.go
+++ b/handler.go
@@ -98,7 +98,6 @@ func (s *Server) Resource(w http.ResponseWriter, r *http.Request) {
 	var (
 		res          *http.Response
 		resBodyBytes []byte
-		indentedJSON []byte
 		err          error
 	)
 
@@ -123,18 +122,7 @@ func (s *Server) Resource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m := map[string]string{}
-	if err = json.Unmarshal(resBodyBytes, &m); err != nil {
-		s.renderError(w, ErrorDetails{http.StatusInternalServerError, fmt.Sprintf("failed to unmarshal response from resource server %v", err)})
-		return
-	}
-
-	if indentedJSON, err = json.MarshalIndent(m, "", "\t"); err != nil {
-		s.renderError(w, ErrorDetails{http.StatusInternalServerError, fmt.Sprintf("failed to marshal the response %v", err)})
-		return
-	}
-
-	resourceRes := map[string]interface{}{"Status": res.StatusCode, "Content": string(indentedJSON)}
+	resourceRes := map[string]interface{}{"Status": res.StatusCode, "Content": string(resBodyBytes)}
 	s.Tmpl.ExecuteTemplate(w, "resource", resourceRes)
 }
 


### PR DESCRIPTION
## AUT-5242 - [sample app doesn't display non-JSON resource server response](https://cloudentity.atlassian.net/browse/AUT-5242)


## Description
The sample app displays only JSON response type from resource server. This PR adds displaying the response body of any type.


## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

